### PR TITLE
removed non-existent "table-striped" class

### DIFF
--- a/src/ref/tables.ejs
+++ b/src/ref/tables.ejs
@@ -43,4 +43,4 @@ Tables always comes with full width property.</p>
 </table>
 
 <!-- Table code -->
-<pre>&lt;table class="table table-striped"&gt; ... &lt;/table&gt;</pre>
+<pre>&lt;table class="table"&gt; ... &lt;/table&gt;</pre>


### PR DESCRIPTION
This code sample gives the impression the library ships with a `table-striped` class. It fooled me!